### PR TITLE
Add a note about assuming a role in a different account

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,9 @@ metadata:
   name: default
 ```
 
+_Note:_ If you use both `--namespace-restrictions` and `--auto-discover-base-arn` flags, it is possible to assume a role in a different account (hence with a different base ARN) but the `iam.amazonaws.com/allowed-roles` annotation must explicitly include the base ARN. 
+
+
 ### RBAC Setup
 
 This is the basic RBAC setup to get kube2iam working correctly when your cluster is using rbac. Below is the bare minimum to get kube2iam working.


### PR DESCRIPTION
#### What this PR does / why we need it:

When kube2iam is configured with both  `--namespace-restrictions` and `--auto-discover-base-arn`, we had some trouble finding how to allow it to assume a role in a different account.
By digging into the code we saw that it was possible by explicitly including the external base ARN to the `iam.amazonaws.com/allowed-roles` namespace annotation (before we only had regexp, which concerned only the roles in the current base ARN)

This PR aims to add a note about this behavior in the documentation to help users getting this information easier.